### PR TITLE
Add support to configure the Odoo service with environment variables.

### DIFF
--- a/.envs/.local/.odoo
+++ b/.envs/.local/.odoo
@@ -1,0 +1,2 @@
+SMTP_SERVER=mailhog
+SMTP_PORT=1025

--- a/Dockerfile
+++ b/Dockerfile
@@ -19,6 +19,8 @@ RUN apt install libpq-dev -y
 RUN apt install libxml2-dev -y
 RUN apt install libxslt1-dev libldap2-dev  -y
 RUN apt install libsasl2-dev libffi-dev -y
+# To use envsubst
+RUN apt install gettext-base -y
 
 # install node  https://packages.debian.org/bullseye/arm64/nodejs
 # npm https://packages.debian.org/bullseye/arm64/npm

--- a/compose/start
+++ b/compose/start
@@ -4,5 +4,9 @@ set -o errexit
 set -o pipefail
 set -o nounset
 
-python ./odoo-bin -c /etc/config/odoo-server.conf
+# Input: /etc/config/odoo-server.conf
+# Output: /tmp/config/env-odoo-server.conf (after variable substitution)
+envsubst < /etc/config/odoo-server.conf > /tmp/config/env-odoo-server.conf
+
+python ./odoo-bin -c /tmp/config/env-odoo-server.conf
 

--- a/config/odoo-server.conf
+++ b/config/odoo-server.conf
@@ -1,9 +1,11 @@
 [options]
-db_host = postgresql
-db_port = 5432
-db_user = local_user
-db_name = local_db
-db_password = super_secret_password
+; Config database
+db_host = $POSTGRES_HOST
+db_port = $POSTGRES_PORT
+db_user = $POSTGRES_USER
+db_name = $POSTGRES_DB
+db_password = $POSTGRES_PASSWORD
 
-smtp_server = mailhog
-smtp_port = 1025
+;
+smtp_server = $SMTP_SERVER
+smtp_port = $SMTP_PORT


### PR DESCRIPTION

**Changes:**
1. Added support for configuring the Odoo service with environment variables.
   - Added `.envs/.local/.odoo` file with the following environment variables:
     ```
     SMTP_SERVER=mailhog
     SMTP_PORT=1025
     ```

2. Updated the Dockerfile:
   - Installed `gettext-base` package for using `envsubst`.

3. Updated `compose/start` file:
   - Replaced the command to run Odoo with variable substitution.
   - Used the `/tmp/config/env-odoo-server.conf` file as the configuration file.

4. Updated `config/odoo-server.conf` file:
   - Replaced hard-coded values with environment variable references.